### PR TITLE
Update react-dom to 15.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,13 +3111,14 @@
       }
     },
     "react-dom": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.1.tgz",
-      "integrity": "sha1-1UyRMmGq7bF63CBBDQKdzBihNEo=",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
+      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10"
       },
       "dependencies": {
         "asap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-table-editor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki-table-editor",
   "main": "src/wiki-table-editor.jsx",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "dependencies": {
     "lodash": "4.17.4",
     "react": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-table-editor",
-  "main": "dist/wiki-table-editor.js",
+  "main": "src/wiki-table-editor.jsx",
   "version": "1.0.1",
   "dependencies": {
     "lodash": "4.17.4",
@@ -8,7 +8,7 @@
     "react-dnd": "2.2.4",
     "react-dnd-html5-backend": "2.2.4",
     "react-dnd-multi-backend": "git+https://github.com/iFixit/react-dnd-multi-backend.git",
-    "react-dom": "15.4.1",
+    "react-dom": "^15.6.1",
     "reactabular": "8.3.0",
     "reactabular-dnd": "8.7.1",
     "reactabular-table": "8.6.0",
@@ -28,7 +28,6 @@
   },
   "scripts": {
     "build": "webpack",
-    "build-dev": "webpack --env.dev",
-    "prepare": "npm run build"
+    "build-dev": "webpack --env.dev"
   }
 }


### PR DESCRIPTION
This also reverts the change to target `dist/wiki-table-editor.js`
because the prepare script failed due to us not packaging this
correctly. The fix needs a little more work.

cr_req 1